### PR TITLE
add missing java plugin dependency, set correct scala version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,12 +1,14 @@
 name := "ScalaChainDebugger"
 version := "0.1"
-scalaVersion := "2.13.0-M5"
+scalaVersion := "2.12.7"
 
 ideaPluginName in ThisBuild := name.value
 ideaBuild in ThisBuild := "192.5728.98"
 
-ideaInternalPlugins += "stream-debugger"
-ideaExternalPlugins += IdeaPlugin.Id("Scala", "org.intellij.scala", Some("Stable"))
-
 lazy val ScalaChainDebugger: sbt.Project = project.in(file("."))
+  .settings(
+    ideaInternalPlugins ++= Seq("stream-debugger", "java"),
+    ideaExternalPlugins += IdeaPlugin.Id("Scala", "org.intellij.scala", None)
+  )
+
 lazy val ideaRunner = createRunnerProject(ScalaChainDebugger, "idea-runner")


### PR DESCRIPTION
After these changes projects imports/compiles/runs fine, but some manual intervention is required before the following issues are fixed in "sbt-idea-plugin":

https://github.com/JetBrains/sbt-idea-plugin/issues/13
https://github.com/JetBrains/sbt-idea-plugin/issues/13
https://github.com/JetBrains/sbt-idea-plugin/issues/11

- `Scala` folder from `~/.ScalaChainDebuggerPluginIC/sdk/192.5728.74/externalPlugins` must be copied to `~/.ScalaChainDebuggerPluginIC/sdk/192.5728.74/plugins`
- `scala-library` from imported 'idea-runner' module should be removed
- "Build ScalaChainDebugger artifact" should be included in the generated run configuration "Before build ..."
